### PR TITLE
Allow user to update alerts with multiple email addresses

### DIFF
--- a/le_alert-email-change/README.md
+++ b/le_alert-email-change/README.md
@@ -1,14 +1,14 @@
 le_alert-util
 =========
 
-Script to configure all alerts to use a user supplied email address for a given host.
+Script to configure all alerts to use supplied email addresses for a given host.
 
 Setup
 -----
 
 Run the following command,
 
-	python le_alert-email-change.py ACCOUNT_KEY HOST_NAME EMAIL
+    python le_alert-email-change.py ACCOUNT_KEY HOST_NAME EMAIL
 
 You can find your Logentries Account Key here https://logentries.com/doc/accountkey/
 
@@ -17,4 +17,4 @@ Your HOST_NAME is the one configured under "Hosts" in the logentries sidebar
 
 A sample command would be,
 
-	python le_alert-email-change.py 12345 MyHost stephen@logentries.com
+    python le_alert-email-change.py 12345 MyHost stephen1@logentries.com[ stephen2@logentries.com[ ...]

--- a/le_alert-email-change/le_alert-email-change.py
+++ b/le_alert-email-change/le_alert-email-change.py
@@ -9,9 +9,8 @@ EMAIL = ''
 
 
 def setup():
-    #Probably use something better then regex to validate email
-    key = re.search(".+@.+\..+",EMAIL)
-    if key is not None:
+    # TODO: Probably use something better then regex to validate email
+    if all(re.search(".+@.+\..+", email) is not None for email in EMAIL_LIST): 
         get_hosts()
     else:
         print "Not a valid email address."
@@ -43,7 +42,7 @@ def retrieve_actions(log_keys):
         try:
             if action['args']['direct']:
                 print action['args']['direct']
-                action['args']['direct'] = EMAIL
+                action['args']['direct'] = ','.join(EMAIL_LIST)
                 update_action(action)
         except KeyError, e:
                 print ""
@@ -73,5 +72,5 @@ def update_action(action):
 if __name__ == '__main__':
     ACCOUNT_KEY = sys.argv[1]
     HOST_NAME = sys.argv[2]
-    EMAIL = sys.argv[3]
+    EMAIL_LIST = sys.argv[3:]
     setup()


### PR DESCRIPTION
If multiple sysadmins need to receive alerts, user should be able to update their alerts and tags with multiple email addresses. This seems like what the Teams arg should be used for, but I am unable to use Teams in the current web UI.