### PR TITLE
Update le_add_logset_to_alert to support adding alerts for a specific log

### DIFF
--- a/le_add_logset_to_alert/README.md
+++ b/le_add_logset_to_alert/README.md
@@ -18,5 +18,8 @@ To run the script:
 
 A sample command would be:
 
-    python le_add_logset_to_alert.py XXXX MyAlert MyLogSet
+    python le_add_logset_to_alert.py XXXX MyAlert HOST
 
+or
+
+    python le_add_logset_to_alert.py XXXX MyAlert HOST/LOGSET

--- a/le_add_logset_to_alert/le_add_logset_to_alert.py
+++ b/le_add_logset_to_alert/le_add_logset_to_alert.py
@@ -13,17 +13,22 @@ def main(account_key, alert_name, log_set_name):
 
 
 def get_log_set_keys(account_key, log_set_name):
-    url = 'https://api.logentries.com/%s/hosts/%s' %(account_key, log_set_name)
-    host = {}
-    logs = []
+    url = 'https://api.logentries.com/%s/hosts/%s' % (account_key, log_set_name)
+    log_sets = {}
+    keys = []
     try:
         response = urllib2.urlopen(url).read()
-        host = json.loads(response)
-        for logkey in host['logs']:
-            logs.append(logkey['key'])
+        log_sets = json.loads(response)
+        if 'logs' in log_sets:
+            # log_sets is all logs of a host
+            for logkey in log_sets['logs']:
+                keys.append(logkey['key'])
+        else:
+            # log_sets is the specific log of a host
+            keys.append(log_sets['key'])
     except Exception, e:
         raise e
-    return logs
+    return keys
 
 
 def get_alert(account_key, alert_name):


### PR DESCRIPTION
In Logentries, each log set can contains multiple logs. I create a log set for each server. Every log set contains different logs. Normally, I want to add an alert for the specific log.

Add an alert for all logs in a log set:
```
python le_add_logset_to_alert.py XXXX MyAlert HOST
```
Add an alert for the specific log in a log set:
```
python le_add_logset_to_alert.py XXXX MyAlert HOST/LOG
```
